### PR TITLE
Add DEVELOPMENT_CHARTER.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dist
 .railwayignore
 proxmox-readiness-report-1750537000528.json
 CLAUDE.md
+DEVELOPMENT_CHARTER.md


### PR DESCRIPTION
Updated .gitignore to exclude DEVELOPMENT_CHARTER.md from version control.