### PR TITLE
Rename drug market trend analysis to shortage trend analysis

### DIFF
--- a/official-mcp-server.js
+++ b/official-mcp-server.js
@@ -27,7 +27,7 @@ import {
     searchDrugShortages,
     fetchDrugLabelInfo,
     searchDrugRecalls,
-    analyzeDrugMarketTrends,
+    analyzeDrugShortageTrends,
     batchDrugAnalysis,
     getMedicationProfile,
     searchAdverseEvents,
@@ -191,8 +191,8 @@ const TOOL_DEFINITIONS = [
         }
     },
     {
-        name: "analyze_drug_market_trends",
-        description: "Analyze drug shortage patterns over time. Use when asked about 'shortage trends', 'historical patterns', 'shortage analysis over time', or 'trends for [drug]'.",
+        name: "analyze_drug_shortage_trends",
+        description: "Analyze FDA drug shortage patterns over time. Use when asked about 'shortage trends', 'historical patterns', 'shortage analysis over time', or 'trends for [drug]'.",
         inputSchema: {
             type: "object",
             properties: {
@@ -441,9 +441,9 @@ async function handleToolCall(name, args) {
                 result = await fetchDrugLabelInfo(args.drug_identifier, args.identifier_type || "openfda.generic_name");
                 break;
                 
-            case "analyze_drug_market_trends":
+            case "analyze_drug_shortage_trends":
                 log.tool(name, drugName, `months: ${args.months_back || 12}`);
-                result = await analyzeDrugMarketTrends(args.drug_name, args.months_back || 12);
+                result = await analyzeDrugShortageTrends(args.drug_name, args.months_back || 12);
                 break;
                 
             case "batch_drug_analysis":

--- a/openfda-client.js
+++ b/openfda-client.js
@@ -275,7 +275,7 @@ function daysSince(dateStr) {
 /**
  * Analyze drug shortage trends using FDA historical data
  */
-export async function analyzeDrugMarketTrends(drugName, monthsBack = 12) {
+export async function analyzeDrugShortageTrends(drugName, monthsBack = 12) {
     const validationError = validateDrugName(drugName, "trends");
     if (validationError) return validationError;
 
@@ -400,7 +400,7 @@ export async function batchDrugAnalysis(drugList, includeTrends = false) {
             
             // Get trend data if requested
             if (includeTrends) {
-                analysis.trend_data = await analyzeDrugMarketTrends(drug, 6);
+                analysis.trend_data = await analyzeDrugShortageTrends(drug, 6);
             }
             
         } catch (error) {

--- a/tests/comprehensive-test.js
+++ b/tests/comprehensive-test.js
@@ -74,11 +74,11 @@ function test(description, condition, actual = null, expected = null) {
 
 // Test trend analysis with drugs that have shortages
 async function testTrendsWithShortages() {
-    console.log('\n[TEST] Testing Trend Analysis - Drugs With Shortages');
+    console.log('\n[TEST] Testing Shortage Trend Analysis - Drugs With Shortages');
     
     for (const drug of drugsWithShortages) {
         try {
-            const result = await callTool('analyze_drug_market_trends', {
+            const result = await callTool('analyze_drug_shortage_trends', {
                 drug_name: drug,
                 months_back: 12
             });
@@ -115,11 +115,11 @@ async function testTrendsWithShortages() {
 
 // Test trend analysis with drugs without shortages
 async function testTrendsWithoutShortages() {
-    console.log('\n[TEST] Testing Trend Analysis - Drugs Without Shortages');
+    console.log('\n[TEST] Testing Shortage Trend Analysis - Drugs Without Shortages');
     
     for (const drug of drugsWithoutShortages) {
         try {
-            const result = await callTool('analyze_drug_market_trends', {
+            const result = await callTool('analyze_drug_shortage_trends', {
                 drug_name: drug,
                 months_back: 6
             });
@@ -141,7 +141,7 @@ async function testValidation() {
     
     // Test empty drug name
     try {
-        const result = await callTool('analyze_drug_market_trends', {
+        const result = await callTool('analyze_drug_shortage_trends', {
             drug_name: '',
             months_back: 12
         });
@@ -154,7 +154,7 @@ async function testValidation() {
     
     // Test invalid months_back
     try {
-        const result = await callTool('analyze_drug_market_trends', {
+        const result = await callTool('analyze_drug_shortage_trends', {
             drug_name: 'metformin',
             months_back: 100
         });
@@ -226,7 +226,7 @@ async function testPerformance() {
     const startTime = Date.now();
     
     try {
-        await callTool('analyze_drug_market_trends', {
+        await callTool('analyze_drug_shortage_trends', {
             drug_name: 'Lisdexamfetamine',
             months_back: 12
         });


### PR DESCRIPTION
Refactored function and tool names from 'analyzeDrugMarketTrends' and 'analyze_drug_market_trends' to 'analyzeDrugShortageTrends' and 'analyze_drug_shortage_trends' for clarity and consistency. Updated related descriptions, references, and tests to reflect the new naming focused on FDA drug shortage trends.