### PR TITLE
Add GITHUB_ACTIONS_PLANNING.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ dist
 proxmox-readiness-report-1750537000528.json
 CLAUDE.md
 DEVELOPMENT_CHARTER.md
+GITHUB_ACTIONS_PLANNING.md


### PR DESCRIPTION
Updated .gitignore to exclude GITHUB_ACTIONS_PLANNING.md from version control.