### PR TITLE
Update Docker image name in workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository_owner }}/certus_server
 
 jobs:
   docker-build:


### PR DESCRIPTION
Changed the IMAGE_NAME environment variable to use the repository owner and 'certus_server' instead of the full repository name for Docker builds.