### PR TITLE
Update Docker workflow permissions and SARIF upload

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
       
     steps:
     - name: Checkout code
@@ -70,6 +71,7 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-results.sarif'
+      continue-on-error: true
         
   test-docker-image:
     name: Test Docker Image


### PR DESCRIPTION
Added 'security-events: write' permission to the Docker workflow and set 'continue-on-error: true' for the SARIF upload step to improve security event reporting and workflow resilience.