### PR TITLE
Refactor README and add modular documentation guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,34 @@
+# Documentation
+
+Detailed documentation for Certus OpenFDA MCP Server.
+
+## Quick Navigation
+
+### [Deployment Guide](deployment-guide.md)
+Complete guide for deploying your own Certus server including Docker, Railway, self-hosted, and Proxmox deployment options.
+
+### [Testing and Validation Guide](testing-guide.md) 
+Comprehensive testing documentation including unit tests, MCP inspector usage, API testing, and deployment validation.
+
+### [Troubleshooting Guide](troubleshooting-guide.md)
+Detailed troubleshooting guide covering common issues, debug commands, performance problems, and error resolution.
+
+### [Configuration Guide](configuration-guide.md)
+Complete configuration reference including environment variables, caching behavior, security settings, and production deployment.
+
+## Main Documentation
+
+Return to the [main README](../README.md) for:
+- Quick start guide
+- Live chatbot demo
+- Key features overview
+- System architecture
+- Available tools reference
+
+## Getting Started
+
+1. **New users**: Start with the main [README](../README.md)
+2. **Deploying your own**: See [Deployment Guide](deployment-guide.md)
+3. **Testing setup**: Use [Testing Guide](testing-guide.md)
+4. **Having issues**: Check [Troubleshooting Guide](troubleshooting-guide.md)
+5. **Advanced setup**: Refer to [Configuration Guide](configuration-guide.md)

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -1,0 +1,629 @@
+# Configuration Guide
+
+Complete configuration reference for Certus MCP Server.
+
+## Environment Variables
+
+### Basic Configuration
+
+```bash
+# FDA API Configuration
+OPENFDA_API_KEY=your_fda_api_key_here
+
+# Server Configuration
+PORT=3000
+NODE_ENV=production
+
+# Logging Configuration
+LOG_LEVEL=info
+LOG_FILE=/var/log/certus-server.log
+```
+
+### FDA API Key Setup
+
+**Why you need an API key:**
+- Without key: 1,000 requests/day
+- With key: 120,000 requests/day
+- Reduces rate limiting issues
+- Better performance for heavy usage
+
+**Getting an API key:**
+
+1. Visit: https://open.fda.gov/apis/authentication/
+2. Click "Get API Key"
+3. Fill out the registration form
+4. Verify your email address
+5. API key will be sent via email
+
+**Using the API key:**
+
+```bash
+# In .env file
+OPENFDA_API_KEY=your_actual_api_key_here
+
+# As environment variable
+export OPENFDA_API_KEY=your_actual_api_key_here
+
+# In Docker
+docker run -e OPENFDA_API_KEY=your_key ghcr.io/zesty-genius128/certus_server:latest
+
+# In Docker Compose
+environment:
+  - OPENFDA_API_KEY=your_key
+```
+
+### Port Configuration
+
+**Default ports:**
+- Development: 3000
+- Production: 443 (HTTPS) or 80 (HTTP)
+
+**Port configuration options:**
+
+```bash
+# Standard HTTP
+PORT=3000
+
+# HTTPS (requires SSL certificates)  
+PORT=443
+
+# Custom port
+PORT=8080
+```
+
+**Port considerations:**
+
+- **Port 443/80**: Requires root privileges or special configuration
+- **Port 3000+**: Safe for non-root users
+- **Docker**: Map container port to host port (`-p host:container`)
+
+### Logging Configuration
+
+```bash
+# Log levels: error, warn, info, debug
+LOG_LEVEL=info
+
+# Log file location (optional)
+LOG_FILE=/var/log/certus-server.log
+
+# Disable console logging (optional)
+DISABLE_CONSOLE_LOGGING=false
+
+# Log format: json, simple
+LOG_FORMAT=simple
+```
+
+## Rate Limiting Configuration
+
+### FDA API Rate Limits
+
+**Without API key:**
+- 1,000 requests per day
+- 40 requests per minute (burst)
+- Resets at midnight EST
+
+**With API key:**
+- 120,000 requests per day  
+- 240 requests per minute (sustained)
+- Better burst capacity
+
+### Client-Side Rate Limiting
+
+The server implements intelligent rate limiting:
+
+```javascript
+// Built-in rate limiting (not configurable via environment)
+const rateLimits = {
+  requestsPerMinute: 60,
+  burstCapacity: 10,
+  windowSizeMs: 60000
+};
+```
+
+## Caching Configuration
+
+### Medical Safety-First Caching
+
+Caching behavior is designed around medical data safety and cannot be modified via configuration to ensure patient safety.
+
+### Current Caching Implementation
+
+**Cached Data Types:**
+- **Drug Labels**: 24-hour TTL (static prescribing information)
+- **Drug Shortages**: 30-minute TTL (rapidly changing supply data)
+- **Adverse Events**: 1-hour TTL (balancing safety with performance)
+
+**Never Cached (Always Fresh):**
+- **Drug Recalls**: Urgent safety alerts must always be current
+- **Serious Adverse Events**: Life-threatening data requires immediate freshness
+
+**Medical Safety Rationale:**
+
+We cache data based on how quickly it changes and its safety impact:
+
+- **Drug recalls** can happen at any time and serious adverse events involve life-threatening situations
+- Caching this data could mean a doctor sees outdated information during an emergency
+- **Drug labels** rarely change, so 24-hour caching is safe
+- **Drug shortages** change frequently but aren't usually life-threatening emergencies (30-minute cache)
+- **Regular adverse events** are cached for 1 hour to balance safety with performance
+
+### Cache Management
+
+**Automatic cleanup:**
+- Runs every hour
+- Removes expired entries
+- Prevents memory leaks
+
+**Manual cache management:**
+
+```bash
+# Check cache statistics
+curl https://your-server.com/cache-stats
+
+# Manual cache cleanup
+curl -X POST https://your-server.com/cache-cleanup
+```
+
+**Cache statistics format:**
+
+```json
+{
+  "timestamp": "2025-08-06T12:00:00.000Z",
+  "status": "active",
+  "cache": {
+    "totalEntries": 4,
+    "memoryUsageApprox": 4096,
+    "entriesByType": {
+      "drug_labels": 2,
+      "drug_shortages": 1, 
+      "adverse_events": 1,
+      "drug_recalls": 0,
+      "serious_adverse_events": 0
+    }
+  },
+  "cleanup": {
+    "interval": "1 hour",
+    "next_cleanup": "automatic"
+  }
+}
+```
+
+## Security Configuration
+
+### HTTPS Configuration
+
+**For production deployments, always use HTTPS.**
+
+**With reverse proxy (recommended):**
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name your-domain.com;
+    
+    ssl_certificate /path/to/certificate.crt;
+    ssl_private_key /path/to/private.key;
+    
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+**Direct HTTPS (advanced):**
+
+```bash
+# Requires SSL certificate files
+SSL_CERT_PATH=/path/to/certificate.crt
+SSL_KEY_PATH=/path/to/private.key
+PORT=443
+```
+
+### CORS Configuration
+
+CORS is enabled by default for broad compatibility. The current configuration allows:
+
+- All origins (`*`)
+- Common HTTP methods (GET, POST, OPTIONS)
+- Standard headers (Content-Type, Authorization)
+
+**Built-in CORS settings:**
+
+```javascript
+// CORS configuration (not modifiable via environment)
+const corsOptions = {
+  origin: '*',
+  methods: ['GET', 'POST', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization']
+};
+```
+
+### API Security
+
+**API key security:**
+- Store API keys in environment variables (never in code)
+- Use different keys for development/production
+- Rotate keys periodically
+- Monitor key usage
+
+**Server security:**
+- Run as non-root user
+- Use HTTPS in production
+- Keep dependencies updated
+- Monitor for security advisories
+
+## MCP Protocol Configuration
+
+### Protocol Version
+
+The server implements MCP 2024-11-05 specification:
+
+```javascript
+// Fixed protocol configuration
+const mcpConfig = {
+  protocol: "mcp/2024-11-05",
+  capabilities: {
+    tools: { listChanged: true },
+    resources: { listChanged: false },
+    prompts: { listChanged: false }
+  }
+};
+```
+
+### Transport Configuration
+
+**HTTP Transport (default):**
+- JSON-RPC 2.0 over HTTP POST
+- Endpoint: `/mcp`
+- Content-Type: `application/json`
+
+**Stdio Bridge Compatibility:**
+- Works with `npx mcp-remote`
+- Compatible with all MCP clients
+- Automatic protocol translation
+
+## Tool Configuration
+
+### Available Tools
+
+The server provides 8 FDA drug information tools:
+
+1. `search_drug_shortages`
+2. `get_medication_profile`
+3. `search_drug_recalls`
+4. `get_drug_label_info`
+5. `analyze_drug_shortage_trends`
+6. `search_adverse_events`
+7. `search_serious_adverse_events`
+8. `batch_drug_analysis`
+
+### Tool Limits and Defaults
+
+**Search result limits:**
+- Default: 5-10 results per tool
+- Maximum: 50 results per tool
+- Batch analysis: Up to 25 drugs
+
+**Timeout configuration:**
+- FDA API requests: 15 seconds
+- Tool execution: 30 seconds
+- Total request: 60 seconds
+
+### Error Handling Configuration
+
+**Built-in error handling:**
+- Automatic retry for transient failures
+- Graceful fallback for API errors
+- User-friendly error messages
+- Medical safety warnings
+
+## Docker Configuration
+
+### Docker Environment Variables
+
+```yaml
+version: '3.8'
+services:
+  certus-server:
+    image: ghcr.io/zesty-genius128/certus_server:latest
+    ports:
+      - "443:443"
+    environment:
+      # FDA API Configuration
+      - OPENFDA_API_KEY=your_api_key_here
+      
+      # Server Configuration
+      - PORT=443
+      - NODE_ENV=production
+      
+      # Logging Configuration
+      - LOG_LEVEL=info
+      - LOG_FILE=/app/logs/certus.log
+      
+    volumes:
+      # Persistent logs
+      - ./logs:/app/logs
+      
+    restart: unless-stopped
+    
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:443/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+```
+
+### Docker Resource Limits
+
+```yaml
+services:
+  certus-server:
+    image: ghcr.io/zesty-genius128/certus_server:latest
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '0.5'
+        reservations:
+          memory: 256M
+          cpus: '0.25'
+```
+
+### Docker Security Configuration
+
+```yaml
+services:
+  certus-server:
+    image: ghcr.io/zesty-genius128/certus_server:latest
+    
+    # Security options
+    user: "1001:1001"  # Non-root user
+    read_only: true    # Read-only filesystem
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE  # Only if binding to port 80/443
+    
+    tmpfs:
+      - /tmp
+      - /app/tmp
+```
+
+## Production Configuration
+
+### Recommended Production Settings
+
+```bash
+# Production environment file (.env)
+NODE_ENV=production
+PORT=443
+OPENFDA_API_KEY=your_production_api_key
+
+# Logging
+LOG_LEVEL=warn
+LOG_FILE=/var/log/certus-server.log
+DISABLE_CONSOLE_LOGGING=true
+
+# Security
+SSL_CERT_PATH=/etc/ssl/certs/certus.crt
+SSL_KEY_PATH=/etc/ssl/private/certus.key
+```
+
+### System Service Configuration
+
+**Systemd service file** (`/etc/systemd/system/certus-server.service`):
+
+```ini
+[Unit]
+Description=Certus OpenFDA MCP Server
+After=network.target
+
+[Service]
+Type=simple
+User=certus
+Group=certus
+WorkingDirectory=/opt/certus-server
+ExecStart=/usr/bin/node official-mcp-server.js
+Restart=always
+RestartSec=10
+
+# Environment
+Environment=NODE_ENV=production
+Environment=PORT=3000
+EnvironmentFile=-/opt/certus-server/.env
+
+# Security
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/certus-server/logs
+
+# Resource limits
+LimitNOFILE=65536
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### PM2 Configuration
+
+**PM2 ecosystem file** (`ecosystem.config.js`):
+
+```javascript
+module.exports = {
+  apps: [{
+    name: 'certus-server',
+    script: 'official-mcp-server.js',
+    instances: 1,
+    exec_mode: 'cluster',
+    
+    // Environment
+    env: {
+      NODE_ENV: 'production',
+      PORT: 3000
+    },
+    
+    // Resource limits
+    max_memory_restart: '512M',
+    
+    // Logging
+    log_file: '/var/log/certus-server.log',
+    error_file: '/var/log/certus-server-error.log',
+    out_file: '/var/log/certus-server-out.log',
+    log_date_format: 'YYYY-MM-DD HH:mm:ss',
+    
+    // Restart policy
+    restart_delay: 5000,
+    max_restarts: 10,
+    min_uptime: '10s'
+  }]
+};
+```
+
+## Development Configuration
+
+### Development Environment
+
+```bash
+# Development environment file (.env.development)
+NODE_ENV=development
+PORT=3000
+
+# Logging (more verbose)
+LOG_LEVEL=debug
+DISABLE_CONSOLE_LOGGING=false
+
+# Development FDA API key (optional)
+OPENFDA_API_KEY=your_development_api_key
+```
+
+### Development Scripts
+
+```json
+{
+  "scripts": {
+    "dev": "NODE_ENV=development nodemon official-mcp-server.js",
+    "start": "NODE_ENV=production node official-mcp-server.js",
+    "test": "NODE_ENV=test node tests/unit-tests.js",
+    "debug": "NODE_ENV=development node --inspect official-mcp-server.js"
+  }
+}
+```
+
+### Hot Reloading with Nodemon
+
+```bash
+# Install nodemon for development
+npm install -g nodemon
+
+# Start with auto-reload
+nodemon official-mcp-server.js
+
+# With custom config
+nodemon --watch "*.js" --ignore node_modules/ official-mcp-server.js
+```
+
+## Monitoring Configuration
+
+### Health Check Configuration
+
+**Built-in health endpoint:**
+- URL: `/health`
+- Method: GET
+- Response: JSON with server status
+
+**Health check response format:**
+
+```json
+{
+  "status": "healthy",
+  "timestamp": "2025-08-06T12:00:00.000Z",
+  "uptime": 3600,
+  "memory": {
+    "used": "45.2 MB",
+    "total": "512 MB",
+    "percentage": 8.8
+  },
+  "fdaApiStatus": "operational",
+  "toolsAvailable": 8,
+  "cacheStatus": "active"
+}
+```
+
+### Monitoring Integration
+
+**Prometheus metrics** (if monitoring enabled):
+
+```bash
+# Custom metrics endpoint
+curl http://localhost:3000/metrics
+
+# Basic metrics available:
+# - http_requests_total
+# - http_request_duration_seconds
+# - nodejs_memory_usage_bytes
+# - fda_api_requests_total
+# - cache_operations_total
+```
+
+**Log aggregation:**
+
+```bash
+# Structured logging for log aggregation
+LOG_FORMAT=json
+LOG_LEVEL=info
+```
+
+## Troubleshooting Configuration Issues
+
+### Configuration Validation
+
+```bash
+# Test configuration
+node -e "
+const config = {
+  port: process.env.PORT || 3000,
+  apiKey: process.env.OPENFDA_API_KEY || 'not_set',
+  nodeEnv: process.env.NODE_ENV || 'development'
+};
+console.log('Configuration:', JSON.stringify(config, null, 2));
+"
+```
+
+### Common Configuration Problems
+
+**Environment variables not loaded:**
+```bash
+# Check if .env file is in correct location
+ls -la .env
+
+# Test environment variable loading
+node -e "require('dotenv').config(); console.log(process.env.OPENFDA_API_KEY);"
+```
+
+**Port binding issues:**
+```bash
+# Check if port is available
+netstat -tulpn | grep :443
+
+# Test port binding permission
+sudo setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/node
+```
+
+**SSL certificate issues:**
+```bash
+# Validate certificate files
+openssl x509 -in certificate.crt -text -noout
+openssl rsa -in private.key -check
+```
+
+For detailed troubleshooting, see the [Troubleshooting Guide](troubleshooting-guide.md).

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1,0 +1,458 @@
+# Deployment Guide
+
+Complete guide for deploying your own Certus MCP Server.
+
+## Prerequisites
+
+- Node.js 18+ (tested on 18.x, 20.x, 22.x)
+- Docker (recommended) or cloud platform account
+- Git
+
+## Docker Deployment (Recommended)
+
+### Quick Start
+
+```bash
+docker run -d -p 443:443 \
+  --name certus-server \
+  --restart unless-stopped \
+  ghcr.io/zesty-genius128/certus_server:latest
+```
+
+### Docker Compose Deployment
+
+```bash
+curl -O https://raw.githubusercontent.com/zesty-genius128/Certus_server/main/docker-compose.yml
+docker-compose up -d
+```
+
+### Custom Docker Configuration
+
+```yaml
+version: '3.8'
+services:
+  certus-server:
+    image: ghcr.io/zesty-genius128/certus_server:latest
+    ports:
+      - "443:443"
+    environment:
+      - OPENFDA_API_KEY=your_api_key_here
+      - PORT=443
+    volumes:
+      - ./logs:/app/logs
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:443/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+```
+
+### Docker Features
+
+- **Multi-platform support**: AMD64 and ARM64 architectures
+- **Automatic security scanning**: Trivy vulnerability scanning during build
+- **Production-optimized**: Alpine Linux base for minimal footprint
+- **Health checks**: Built-in health monitoring with auto-restart
+- **Non-root user**: Enhanced security with user ID 1001
+- **Automatic updates**: Pull latest image and restart for updates
+
+### Testing Docker Deployment
+
+```bash
+# Check container status
+docker ps
+
+# Check health
+curl http://localhost:443/health
+
+# View logs
+docker logs certus-server
+
+# Test drug search
+curl -X POST http://localhost:443/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search_drug_shortages",
+      "arguments": {"drug_name": "insulin", "limit": 3}
+    }
+  }'
+```
+
+## Manual Installation from Source
+
+### Clone and Setup
+
+```bash
+git clone https://github.com/zesty-genius128/Certus_server.git
+cd Certus_server
+npm install
+```
+
+### Development Mode
+
+```bash
+# Start in development mode with auto-reload
+npm run dev
+
+# Start in production mode
+npm start
+```
+
+### Testing Local Installation
+
+```bash
+# Test health endpoint
+curl http://localhost:3000/health
+
+# Test MCP protocol
+npx @modelcontextprotocol/inspector http://localhost:3000/mcp
+
+# Run unit tests
+npm run test:unit:local
+```
+
+## Railway Cloud Deployment
+
+### Prerequisites
+
+- Railway account (free tier available)
+- Railway CLI installed
+
+### Deployment Steps
+
+```bash
+# Install Railway CLI
+npm install -g @railway/cli
+
+# Login to Railway
+railway login
+
+# Initialize project in existing directory
+railway init
+
+# Deploy to Railway
+railway up
+
+# Get your deployment URL
+railway domain
+
+# Check deployment status
+railway status
+```
+
+### Railway Configuration
+
+Create `railway.json` for custom configuration:
+
+```json
+{
+  "deploy": {
+    "startCommand": "npm start",
+    "healthcheckPath": "/health"
+  }
+}
+```
+
+### Railway Environment Variables
+
+Set these in the Railway dashboard:
+
+```bash
+OPENFDA_API_KEY=your_fda_api_key_here
+PORT=443
+NODE_ENV=production
+```
+
+## Self-Hosted Server Deployment
+
+### VPS/Dedicated Server Setup
+
+```bash
+# Copy files to server
+scp -r . user@your-server:/opt/certus-server/
+
+# Connect to server and setup
+ssh user@your-server
+cd /opt/certus-server
+
+# Install dependencies
+npm install --production
+
+# Start server
+npm start
+```
+
+### Production Setup with PM2
+
+```bash
+# Install PM2 globally
+npm install -g pm2
+
+# Start with PM2
+pm2 start official-mcp-server.js --name certus-server
+
+# Configure auto-restart on boot
+pm2 save
+pm2 startup
+
+# Monitor the application
+pm2 monit
+
+# View logs
+pm2 logs certus-server
+```
+
+### Nginx Reverse Proxy Setup
+
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+    
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
+
+### SSL Certificate with Let's Encrypt
+
+```bash
+# Install Certbot
+sudo apt install certbot python3-certbot-nginx
+
+# Get SSL certificate
+sudo certbot --nginx -d your-domain.com
+
+# Auto-renewal setup
+sudo crontab -e
+# Add line: 0 12 * * * /usr/bin/certbot renew --quiet
+```
+
+## Proxmox Container Deployment
+
+### LXC Container Setup
+
+```bash
+# Create Ubuntu 22.04 LXC container
+pct create 200 ubuntu-22.04-standard_22.04-1_amd64.tar.zst \
+  --memory 2048 \
+  --cores 2 \
+  --hostname certus-server \
+  --net0 name=eth0,bridge=vmbr0,ip=dhcp
+
+# Start container
+pct start 200
+
+# Enter container
+pct enter 200
+
+# Install Node.js
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+apt-get install -y nodejs
+
+# Clone and setup Certus
+git clone https://github.com/zesty-genius128/Certus_server.git /opt/certus-server
+cd /opt/certus-server
+npm install --production
+```
+
+### Systemd Service Setup
+
+Create `/etc/systemd/system/certus-server.service`:
+
+```ini
+[Unit]
+Description=Certus OpenFDA MCP Server
+After=network.target
+
+[Service]
+Type=simple
+User=node
+WorkingDirectory=/opt/certus-server
+ExecStart=/usr/bin/node official-mcp-server.js
+Restart=always
+RestartSec=10
+Environment=NODE_ENV=production
+Environment=PORT=443
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start the service:
+
+```bash
+# Create node user
+useradd -r -s /bin/false node
+chown -R node:node /opt/certus-server
+
+# Enable and start service
+systemctl enable certus-server
+systemctl start certus-server
+systemctl status certus-server
+```
+
+## Configuration After Deployment
+
+### Update Claude Desktop Config
+
+Replace `your-server.com` with your actual domain:
+
+```json
+{
+  "mcpServers": {
+    "Certus": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://your-server.com/mcp"]
+    }
+  }
+}
+```
+
+For HTTP (development only):
+
+```json
+{
+  "mcpServers": {
+    "Certus": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://your-server.com:3000/mcp", "--allow-http"]
+    }
+  }
+}
+```
+
+### Verify Deployment
+
+```bash
+# Check health
+curl https://your-server.com/health
+
+# List available tools
+curl https://your-server.com/tools
+
+# Test MCP protocol
+npx @modelcontextprotocol/inspector https://your-server.com/mcp
+
+# Run comprehensive tests
+TEST_SERVER_URL=https://your-server.com npm run test:unit
+```
+
+## Monitoring and Maintenance
+
+### Health Monitoring
+
+```bash
+# Continuous health check
+watch -n 30 'curl -s https://your-server.com/health | jq'
+
+# Cache statistics
+curl https://your-server.com/cache-stats
+
+# Manual cache cleanup
+curl -X POST https://your-server.com/cache-cleanup
+```
+
+### Log Monitoring
+
+```bash
+# PM2 logs
+pm2 logs certus-server --lines 100
+
+# Docker logs
+docker logs certus-server --tail 100 -f
+
+# System logs
+journalctl -u certus-server -f
+```
+
+### Updates
+
+```bash
+# Docker update
+docker pull ghcr.io/zesty-genius128/certus_server:latest
+docker stop certus-server
+docker rm certus-server
+# Run docker run command again
+
+# Manual update
+git pull origin main
+npm install --production
+pm2 restart certus-server
+```
+
+## Security Considerations
+
+### Firewall Configuration
+
+```bash
+# Allow HTTPS only
+ufw allow 443/tcp
+ufw allow 22/tcp  # SSH access
+ufw enable
+```
+
+### Regular Security Updates
+
+```bash
+# Ubuntu/Debian
+apt update && apt upgrade -y
+
+# Container updates
+docker pull ghcr.io/zesty-genius128/certus_server:latest
+```
+
+### Environment Security
+
+- Use environment variables for API keys (never commit to repository)
+- Enable HTTPS in production
+- Use non-root user for running the application  
+- Keep dependencies updated
+- Monitor security advisories for Node.js and dependencies
+
+## Troubleshooting Deployment
+
+### Common Issues
+
+**Port already in use:**
+```bash
+# Find process using port
+sudo lsof -i :443
+# Kill process or change port
+```
+
+**Permission denied on port 443:**
+```bash
+# Use port 3000 instead, or setup reverse proxy
+# Docker: -p 3000:443
+```
+
+**Out of memory:**
+```bash
+# Increase container memory
+# Docker: --memory 1g
+# PM2: pm2 start --max-memory-restart 1G
+```
+
+**DNS resolution issues:**
+```bash
+# Check DNS
+nslookup your-domain.com
+# Update DNS records if needed
+```
+
+For more troubleshooting help, see the [Troubleshooting Guide](troubleshooting-guide.md).

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -1,0 +1,606 @@
+# Testing and Validation Guide
+
+Comprehensive guide for testing your Certus MCP Server deployment.
+
+## Quick Health Check
+
+```bash
+# Check if server is running
+curl https://certus.opensource.mieweb.org/health
+
+# Test with MCP inspector
+npx @modelcontextprotocol/inspector https://certus.opensource.mieweb.org/mcp
+```
+
+## MCP Inspector Testing
+
+The MCP Inspector is the official tool for testing MCP protocol compliance.
+
+### Installation and Usage
+
+```bash
+# Test production server
+npx @modelcontextprotocol/inspector https://certus.opensource.mieweb.org/mcp
+
+# Test backup server
+npx @modelcontextprotocol/inspector https://certus-server-production.up.railway.app/mcp
+
+# Test local development
+npx @modelcontextprotocol/inspector http://localhost:3000/mcp
+
+# Test your own deployment
+npx @modelcontextprotocol/inspector https://your-server.com/mcp
+```
+
+### What MCP Inspector Validates
+
+- JSON-RPC 2.0 protocol compliance
+- MCP specification adherence
+- Tool schema validation
+- Connection handling
+- Error response formatting
+- Transport layer functionality
+
+### Expected Inspector Results
+
+```json
+{
+  "protocol": "mcp/2024-11-05",
+  "capabilities": {
+    "tools": { "listChanged": true }
+  },
+  "tools": [
+    {
+      "name": "search_drug_shortages",
+      "description": "Search FDA drug shortages database"
+    },
+    {
+      "name": "get_medication_profile", 
+      "description": "Get comprehensive drug information"
+    }
+    // ... 6 more tools
+  ]
+}
+```
+
+## Unit Testing
+
+### Built-in Test Suite
+
+The project includes comprehensive unit tests covering all functionality:
+
+```bash
+# Run all unit tests (default: localhost)
+npm run test:unit
+
+# Test against your own deployment  
+TEST_SERVER_URL=https://your-server.com npm run test:unit
+
+# Test against local development server
+npm run test:unit:local
+
+# Test against production server (maintainer use)
+npm run test:unit:production
+```
+
+### Test Coverage
+
+The unit tests validate:
+
+**Core Utility Functions:**
+- Drug name validation with context-specific error messages
+- Cache management (TTL validation, expired item handling)
+- API parameter building (URL encoding, API key inclusion)
+- Function imports and exports
+
+**Live Server Integration:**
+- Server health and availability
+- Tool listing and schema validation
+- MCP protocol compliance (JSON-RPC 2.0)
+- All 8 FDA drug information tools
+- Cache statistics and performance monitoring
+
+**Medical Safety Compliance:**
+- Caching behavior for safety-critical vs non-critical data
+- TTL validation for different data types
+- Cache cleanup functionality
+
+### Test Results Interpretation
+
+```bash
+Unit tests loaded successfully. Run with: node --test tests/unit-tests.js
+Testing against server: https://your-server.com
+To test against a different server, set TEST_SERVER_URL environment variable
+
+▶ Drug Name Validation
+  ✔ should accept valid drug names (0.289375ms)
+  ✔ should reject empty or invalid drug names (0.138833ms)
+  ✔ should provide context-specific error messages (0.063625ms)
+✔ Drug Name Validation (1.015333ms)
+
+▶ Live Server Integration Tests
+  ✔ should connect to server health endpoint (1280ms)
+  ✔ should list all 8 FDA tools via MCP endpoint (226ms)
+  ✔ should execute drug shortage search via live server (83ms)
+  ✔ should get cache statistics from live server (189ms)
+✔ Live Server Integration Tests (1778ms)
+```
+
+### Custom Test Configuration
+
+For testing your own deployment:
+
+1. Deploy the server to your infrastructure
+2. Set `TEST_SERVER_URL` environment variable
+3. Run `npm run test:unit` to validate
+
+Example:
+```bash
+export TEST_SERVER_URL=https://my-server.example.com
+npm run test:unit
+```
+
+## Direct API Testing
+
+### Tool Testing with cURL
+
+Test individual FDA tools directly using the MCP JSON-RPC protocol:
+
+#### Drug Shortage Search
+
+```bash
+curl -X POST https://certus.opensource.mieweb.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search_drug_shortages",
+      "arguments": {"drug_name": "insulin", "limit": 3}
+    }
+  }'
+```
+
+#### Medication Profile
+
+```bash
+curl -X POST https://certus.opensource.mieweb.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/call",
+    "params": {
+      "name": "get_medication_profile", 
+      "arguments": {"drug_identifier": "metformin"}
+    }
+  }'
+```
+
+#### Drug Recalls Search
+
+```bash
+curl -X POST https://certus.opensource.mieweb.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/call",
+    "params": {
+      "name": "search_drug_recalls",
+      "arguments": {"drug_name": "acetaminophen", "limit": 5}
+    }
+  }'
+```
+
+#### Trend Analysis
+
+```bash
+curl -X POST https://certus.opensource.mieweb.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "tools/call",
+    "params": {
+      "name": "analyze_drug_shortage_trends",
+      "arguments": {"drug_name": "insulin", "months_back": 12}
+    }
+  }'
+```
+
+#### Batch Analysis
+
+```bash
+curl -X POST https://certus.opensource.mieweb.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 5,
+    "method": "tools/call",
+    "params": {
+      "name": "batch_drug_analysis",
+      "arguments": {
+        "drug_list": ["insulin", "metformin", "lisinopril"],
+        "include_trends": true
+      }
+    }
+  }'
+```
+
+#### Adverse Events
+
+```bash
+curl -X POST https://certus.opensource.mieweb.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 6,
+    "method": "tools/call",
+    "params": {
+      "name": "search_adverse_events",
+      "arguments": {"drug_name": "aspirin", "limit": 5, "detailed": false}
+    }
+  }'
+```
+
+### Expected Response Format
+
+All tool responses follow JSON-RPC 2.0 format:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Raw FDA API response data here..."
+      }
+    ]
+  }
+}
+```
+
+## Health Check Commands
+
+### Server Health Monitoring
+
+```bash
+# Basic health check
+curl https://certus.opensource.mieweb.org/health
+
+# Detailed health with JSON formatting
+curl -s https://certus.opensource.mieweb.org/health | jq
+
+# Check backup server
+curl https://certus-server-production.up.railway.app/health
+```
+
+Expected health response:
+```json
+{
+  "status": "healthy",
+  "timestamp": "2025-08-06T12:00:00.000Z",
+  "uptime": 3600,
+  "memory": {
+    "used": "45.2 MB",
+    "total": "512 MB"
+  },
+  "fdaApiStatus": "operational"
+}
+```
+
+### Tool Availability Check
+
+```bash
+# List all available tools
+curl https://certus.opensource.mieweb.org/tools
+
+# Pretty print tools list
+curl -s https://certus.opensource.mieweb.org/tools | jq '.tools[].name'
+```
+
+Expected tools list:
+```
+"search_drug_shortages"
+"get_medication_profile"
+"search_drug_recalls"
+"get_drug_label_info"
+"analyze_drug_shortage_trends"
+"search_adverse_events"
+"search_serious_adverse_events"
+"batch_drug_analysis"
+```
+
+### Cache Statistics
+
+```bash
+# Check cache performance
+curl https://certus.opensource.mieweb.org/cache-stats
+
+# Monitor cache in real-time
+watch -n 30 'curl -s https://certus.opensource.mieweb.org/cache-stats | jq'
+```
+
+Expected cache stats:
+```json
+{
+  "timestamp": "2025-08-06T12:00:00.000Z",
+  "status": "active",
+  "cache": {
+    "totalEntries": 4,
+    "memoryUsageApprox": 4096,
+    "entriesByType": {
+      "drug_labels": 2,
+      "drug_shortages": 1,
+      "adverse_events": 1,
+      "drug_recalls": 0,
+      "serious_adverse_events": 0
+    }
+  }
+}
+```
+
+## Performance Testing
+
+### Response Time Validation
+
+```bash
+# Time individual requests
+time curl -s https://certus.opensource.mieweb.org/health
+
+# Measure tool execution time
+time curl -X POST https://certus.opensource.mieweb.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search_drug_shortages",
+      "arguments": {"drug_name": "insulin", "limit": 5}
+    }
+  }'
+```
+
+### Load Testing
+
+```bash
+# Simple concurrent request test
+for i in {1..10}; do
+  curl -s https://certus.opensource.mieweb.org/health &
+done
+wait
+
+# Tool load test
+for i in {1..5}; do
+  curl -X POST https://certus.opensource.mieweb.org/mcp \
+    -H "Content-Type: application/json" \
+    -d '{
+      "jsonrpc": "2.0",
+      "id": '$i',
+      "method": "tools/call", 
+      "params": {
+        "name": "search_drug_shortages",
+        "arguments": {"drug_name": "metformin", "limit": 3}
+      }
+    }' &
+done
+wait
+```
+
+## Comprehensive Test Suite
+
+### Full FDA Tools Validation
+
+The project includes a comprehensive test suite covering all FDA tools:
+
+```bash
+# Run comprehensive test suite
+node tests/comprehensive-test.js
+
+# Run with custom server
+TEST_SERVER_URL=https://your-server.com node tests/comprehensive-test.js
+```
+
+### Test Categories
+
+**Drug Trend Analysis Tests:**
+- Drugs with shortage history
+- Drugs without shortage history
+- Input validation and error handling
+- Edge cases and boundary conditions
+
+**Core FDA Tools Tests:**
+- All 8 FDA drug information tools
+- Parameter validation
+- Response format verification
+- Error handling validation
+
+**Batch Analysis Tests:**
+- Multi-drug processing
+- Trend inclusion options
+- Large batch handling (up to 25 drugs)
+
+**Performance Tests:**
+- Response time validation (under 5 seconds)
+- Cache behavior verification
+- Memory usage monitoring
+
+**Error Handling Tests:**
+- Invalid drug names
+- Malformed requests
+- Rate limit handling
+- Network error recovery
+
+### Test Results Analysis
+
+The comprehensive test suite provides detailed results:
+
+```
+Testing Drug Trend Analysis...
+✓ Insulin shortage trends (732 days duration, 107 events) - 2.1s
+✓ Metformin (no current shortages) - 1.8s
+✓ Invalid drug name validation - 0.3s
+
+Testing Core FDA Tools...
+✓ Drug shortage search - 1.5s
+✓ Medication profile retrieval - 2.3s
+✓ Drug recalls search - 1.7s
+✓ Adverse events search - 2.8s
+
+Testing Batch Analysis...
+✓ Multi-drug analysis (5 drugs) - 4.2s
+✓ Batch with trend analysis - 6.1s
+
+All tests passed: 63/63
+Total execution time: 45.2 seconds
+```
+
+## Deployment Validation
+
+### Post-Deployment Checklist
+
+After deploying your own server, validate:
+
+1. **Health endpoint responds:**
+   ```bash
+   curl https://your-server.com/health
+   ```
+
+2. **All 8 tools available:**
+   ```bash
+   curl https://your-server.com/tools | jq '.tools | length'
+   # Should return: 8
+   ```
+
+3. **MCP protocol compliance:**
+   ```bash
+   npx @modelcontextprotocol/inspector https://your-server.com/mcp
+   ```
+
+4. **Tool functionality:**
+   ```bash
+   TEST_SERVER_URL=https://your-server.com npm run test:unit
+   ```
+
+5. **SSL/HTTPS working:**
+   ```bash
+   curl -I https://your-server.com/health
+   # Should show HTTP/2 200 or HTTP/1.1 200
+   ```
+
+### Integration Testing with MCP Clients
+
+#### Claude Desktop Integration
+
+1. Add server to Claude config
+2. Restart Claude Desktop
+3. Test with: "Check insulin shortage status using FDA data"
+4. Verify tools appear in Claude interface
+
+#### LibreChat Integration
+
+1. Configure stdio-wrapper.js with your server URL
+2. Add to LibreChat MCP configuration
+3. Test drug information queries
+4. Verify responses include FDA data
+
+#### Custom MCP Client Testing
+
+```javascript
+// Example Node.js MCP client test
+const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+
+async function testMCPClient() {
+  const transport = new HttpTransport('https://your-server.com/mcp');
+  const client = new Client(transport);
+  
+  await client.connect();
+  const tools = await client.listTools();
+  console.log('Available tools:', tools.length);
+  
+  const result = await client.callTool('search_drug_shortages', {
+    drug_name: 'insulin',
+    limit: 3
+  });
+  console.log('Tool result:', result);
+}
+```
+
+## Monitoring and Alerting
+
+### Uptime Monitoring
+
+Set up monitoring for your deployment:
+
+```bash
+# Simple uptime script
+#!/bin/bash
+while true; do
+  if ! curl -sf https://your-server.com/health > /dev/null; then
+    echo "$(date): Server down" | tee -a uptime.log
+    # Add alerting here (email, Slack, etc.)
+  fi
+  sleep 300  # Check every 5 minutes
+done
+```
+
+### Log Analysis
+
+Monitor server logs for issues:
+
+```bash
+# Search for errors in logs
+grep -i error /var/log/certus-server.log
+
+# Monitor FDA API errors
+grep "FDA API" /var/log/certus-server.log | grep -i error
+
+# Check for rate limiting
+grep -i "rate limit" /var/log/certus-server.log
+```
+
+### Performance Monitoring
+
+Track performance metrics:
+
+```bash
+# Response time monitoring
+while true; do
+  echo "$(date): $(curl -o /dev/null -s -w '%{time_total}' https://your-server.com/health)s" | tee -a response_times.log
+  sleep 60
+done
+
+# Memory usage tracking (for containers)
+docker stats certus-server --no-stream >> memory_usage.log
+```
+
+## Troubleshooting Test Failures
+
+### Common Test Issues
+
+**Connection timeouts:**
+- Check server is running: `curl https://your-server.com/health`
+- Verify network connectivity
+- Check firewall settings
+
+**Tool count mismatch:**
+- Verify all 8 tools are properly loaded
+- Check server logs for startup errors
+- Validate tool definitions in code
+
+**MCP protocol errors:**
+- Use MCP inspector for detailed diagnostics
+- Check JSON-RPC 2.0 compliance
+- Verify request/response format
+
+**FDA API errors:**
+- Check FDA API status: https://open.fda.gov/apis/status/
+- Verify API key configuration
+- Monitor rate limiting
+
+For detailed troubleshooting steps, see the [Troubleshooting Guide](troubleshooting-guide.md).

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -1,0 +1,611 @@
+# Troubleshooting Guide
+
+Comprehensive troubleshooting guide for Certus MCP Server issues.
+
+## Common Issues and Solutions
+
+### Tool Not Appearing in Claude
+
+**Symptoms:**
+- Certus tools don't show up in Claude Desktop
+- Claude doesn't recognize the MCP server
+
+**Solutions:**
+
+1. **Complete Claude Desktop restart:**
+   ```bash
+   # Kill all Claude processes
+   pkill -f "Claude"
+   # Restart Claude Desktop
+   open -a "Claude Desktop"  # macOS
+   # Or launch from Start menu on Windows
+   ```
+
+2. **Check configuration file syntax:**
+   ```json
+   {
+     "mcpServers": {
+       "Certus": {
+         "command": "npx",
+         "args": ["mcp-remote", "https://certus.opensource.mieweb.org/mcp"]
+       }
+     }
+   }
+   ```
+
+3. **Verify server URL works:**
+   ```bash
+   curl https://certus.opensource.mieweb.org/health
+   npx @modelcontextprotocol/inspector https://certus.opensource.mieweb.org/mcp
+   ```
+
+4. **Check Claude Desktop logs:**
+   - **macOS**: `~/Library/Logs/Claude Desktop/`
+   - **Windows**: `%APPDATA%\Claude\logs\`
+
+5. **Configuration file locations:**
+   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+### Connection Errors
+
+**Symptoms:**
+- "Failed to connect to server" errors
+- Timeout errors when calling tools
+- Intermittent connection issues
+
+**Solutions:**
+
+1. **Test server health:**
+   ```bash
+   # Test main server
+   curl https://certus.opensource.mieweb.org/health
+   
+   # Test backup server if main is down
+   curl https://certus-server-production.up.railway.app/health
+   ```
+
+2. **Check network connectivity:**
+   ```bash
+   # Test DNS resolution
+   nslookup certus.opensource.mieweb.org
+   
+   # Test port access
+   telnet certus.opensource.mieweb.org 443
+   
+   # Check firewall rules
+   # On Windows: Windows Defender Firewall
+   # On macOS: System Preferences > Security & Privacy > Firewall
+   ```
+
+3. **Switch to backup server:**
+   ```json
+   {
+     "mcpServers": {
+       "Certus": {
+         "command": "npx",
+         "args": ["mcp-remote", "https://certus-server-production.up.railway.app/mcp"]
+       }
+     }
+   }
+   ```
+
+4. **Corporate firewall issues:**
+   - Check with IT about HTTPS access to external servers
+   - Request whitelisting for `*.opensource.mieweb.org` and `*.railway.app`
+   - Consider using internal deployment
+
+### No Results Found
+
+**Symptoms:**
+- Tools execute but return "No results found"
+- FDA database queries return empty responses
+- Specific drugs not found
+
+**Solutions:**
+
+1. **Try different drug name variations:**
+   ```bash
+   # Generic vs brand names
+   "metformin" instead of "Glucophage"
+   "acetaminophen" instead of "Tylenol"
+   "ibuprofen" instead of "Advil"
+   ```
+
+2. **Check spelling and formatting:**
+   - Remove extra spaces: "insulin " → "insulin"
+   - Use standard drug names from FDA databases
+   - Avoid abbreviations: "ASA" → "aspirin"
+
+3. **Verify drug exists in FDA database:**
+   ```bash
+   # Test directly against FDA API
+   curl "https://api.fda.gov/drug/label.json?search=openfda.generic_name:insulin&limit=1"
+   ```
+
+4. **Use batch search to find variations:**
+   - Try: "Search for metformin, Glucophage, and metformin hydrochloride"
+   - Use the batch analysis tool with multiple name variations
+
+### Rate Limit Issues
+
+**Symptoms:**
+- "Rate limit exceeded" errors
+- Slow or failed requests during heavy usage
+- HTTP 429 responses
+
+**Solutions:**
+
+1. **Add FDA API key:**
+   ```bash
+   # For your own deployment
+   export OPENFDA_API_KEY=your_fda_api_key_here
+   # Restart server
+   ```
+   
+   Get free API key: https://open.fda.gov/apis/authentication/
+
+2. **Reduce request frequency:**
+   - Wait between requests
+   - Use batch operations for multiple drugs
+   - Avoid rapid successive queries
+
+3. **Use batch operations:**
+   ```bash
+   # Instead of 5 separate requests, use batch analysis
+   "Analyze these drugs: insulin, metformin, lisinopril, aspirin, atorvastatin"
+   ```
+
+4. **Monitor rate limits:**
+   ```bash
+   # Check current usage (if you have API key)
+   curl -H "X-API-Key: your_key" "https://api.fda.gov/drug/label.json?limit=1"
+   # Check response headers for rate limit info
+   ```
+
+### MCP Protocol Errors
+
+**Symptoms:**
+- JSON-RPC errors
+- Protocol version mismatches
+- Invalid request/response format
+
+**Solutions:**
+
+1. **Test with MCP Inspector:**
+   ```bash
+   npx @modelcontextprotocol/inspector https://certus.opensource.mieweb.org/mcp
+   ```
+
+2. **Verify MCP client compatibility:**
+   - Update to latest Claude Desktop version
+   - Check MCP client supports HTTP transport
+   - Ensure JSON-RPC 2.0 compliance
+
+3. **Test raw JSON-RPC:**
+   ```bash
+   curl -X POST https://certus.opensource.mieweb.org/mcp \
+     -H "Content-Type: application/json" \
+     -d '{
+       "jsonrpc": "2.0",
+       "id": 1,
+       "method": "tools/list",
+       "params": {}
+     }'
+   ```
+
+## Advanced Troubleshooting
+
+### Debug Commands
+
+#### Server Status and Capabilities
+
+```bash
+# Check server health and uptime
+curl -s https://certus.opensource.mieweb.org/health | jq
+
+# List all available tools
+curl -s https://certus.opensource.mieweb.org/tools | jq '.tools[].name'
+
+# Get detailed tool schemas
+curl -s https://certus.opensource.mieweb.org/tools | jq '.tools[] | {name, description}'
+```
+
+#### Cache Performance Analysis
+
+```bash
+# Check cache statistics
+curl -s https://certus.opensource.mieweb.org/cache-stats | jq
+
+# Monitor cache in real-time
+watch -n 10 'curl -s https://certus.opensource.mieweb.org/cache-stats | jq'
+
+# Manual cache cleanup if needed
+curl -X POST https://certus.opensource.mieweb.org/cache-cleanup
+```
+
+#### FDA API Direct Testing
+
+```bash
+# Test FDA drug labels API
+curl "https://api.fda.gov/drug/label.json?search=openfda.generic_name:metformin&limit=1"
+
+# Test FDA drug shortages API  
+curl "https://api.fda.gov/drug/shortages.json?search=openfda.generic_name:insulin&limit=1"
+
+# Test FDA enforcement API
+curl "https://api.fda.gov/drug/enforcement.json?search=openfda.generic_name:acetaminophen&limit=1"
+
+# Check FDA API status
+curl "https://api.fda.gov/healthcheck"
+```
+
+#### Network and Connectivity Diagnostics
+
+```bash
+# DNS resolution test
+dig certus.opensource.mieweb.org
+nslookup certus.opensource.mieweb.org 8.8.8.8
+
+# SSL certificate check
+openssl s_client -connect certus.opensource.mieweb.org:443 -servername certus.opensource.mieweb.org
+
+# Trace route to server
+traceroute certus.opensource.mieweb.org
+
+# Check HTTP headers
+curl -I https://certus.opensource.mieweb.org/health
+```
+
+### Performance Issues
+
+#### Slow Response Times
+
+**Symptoms:**
+- Requests take longer than 10 seconds
+- Timeouts in Claude Desktop
+- Poor user experience
+
+**Diagnosis:**
+```bash
+# Measure response times
+time curl -s https://certus.opensource.mieweb.org/health
+
+# Test specific tool performance
+time curl -X POST https://certus.opensource.mieweb.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search_drug_shortages",
+      "arguments": {"drug_name": "insulin", "limit": 5}
+    }
+  }'
+```
+
+**Solutions:**
+1. **Check cache hit rates:**
+   ```bash
+   curl -s https://certus.opensource.mieweb.org/cache-stats | jq '.cache'
+   ```
+
+2. **Monitor FDA API latency:**
+   ```bash
+   time curl "https://api.fda.gov/drug/label.json?search=openfda.generic_name:metformin&limit=1"
+   ```
+
+3. **Consider adding API key:**
+   - FDA API key provides higher rate limits
+   - Reduces chance of throttling
+
+4. **Use smaller result limits:**
+   - Default limits are reasonable (5-10 results)
+   - Avoid requesting large datasets
+
+#### Memory Usage Issues
+
+**Symptoms:**
+- Server becomes unresponsive
+- High memory usage alerts
+- Cache growing too large
+
+**Diagnosis:**
+```bash
+# Check cache statistics
+curl -s https://certus.opensource.mieweb.org/cache-stats | jq '.cache.memoryUsageApprox'
+
+# Monitor memory usage over time
+while true; do
+  echo "$(date): $(curl -s https://certus.opensource.mieweb.org/cache-stats | jq -r '.cache.memoryUsageApprox') bytes"
+  sleep 300
+done
+```
+
+**Solutions:**
+1. **Manual cache cleanup:**
+   ```bash
+   curl -X POST https://certus.opensource.mieweb.org/cache-cleanup
+   ```
+
+2. **Monitor cache growth patterns:**
+   - Check which data types are cached most
+   - Verify automatic cleanup is working
+
+3. **For your own deployment:**
+   - Adjust cache TTL values if needed
+   - Increase container memory limits
+   - Monitor application logs for memory leaks
+
+### SSL/Certificate Issues
+
+**Symptoms:**
+- SSL certificate errors
+- "Insecure connection" warnings
+- HTTPS handshake failures
+
+**Diagnosis:**
+```bash
+# Check certificate details
+openssl s_client -connect certus.opensource.mieweb.org:443 -servername certus.opensource.mieweb.org 2>/dev/null | openssl x509 -noout -dates
+
+# Test certificate chain
+curl -v https://certus.opensource.mieweb.org/health 2>&1 | grep -i certificate
+
+# Check certificate with online tools
+# https://www.ssllabs.com/ssltest/analyze.html?d=certus.opensource.mieweb.org
+```
+
+**Solutions:**
+1. **For development/testing (HTTP only):**
+   ```json
+   {
+     "mcpServers": {
+       "Certus": {
+         "command": "npx",
+         "args": ["mcp-remote", "http://localhost:3000/mcp", "--allow-http"]
+       }
+     }
+   }
+   ```
+
+2. **Update system certificates:**
+   ```bash
+   # macOS
+   brew install ca-certificates
+   
+   # Ubuntu/Debian
+   sudo apt-get update && sudo apt-get install ca-certificates
+   ```
+
+3. **Corporate certificate issues:**
+   - Check with IT about corporate proxy certificates
+   - May need to import corporate root certificates
+
+### Deployment-Specific Issues
+
+#### Docker Container Issues
+
+**Symptoms:**
+- Container won't start
+- Container exits immediately
+- Port binding errors
+
+**Diagnosis:**
+```bash
+# Check container status
+docker ps -a
+
+# View container logs
+docker logs certus-server
+
+# Check port usage
+sudo lsof -i :443
+```
+
+**Solutions:**
+1. **Port already in use:**
+   ```bash
+   # Use different port
+   docker run -d -p 3000:443 --name certus-server ghcr.io/zesty-genius128/certus_server:latest
+   ```
+
+2. **Permission denied on port 443:**
+   ```bash
+   # Use unprivileged port
+   docker run -d -p 8443:443 --name certus-server ghcr.io/zesty-genius128/certus_server:latest
+   ```
+
+3. **Container resource limits:**
+   ```bash
+   # Increase memory limit
+   docker run -d -p 443:443 --memory 1g --name certus-server ghcr.io/zesty-genius128/certus_server:latest
+   ```
+
+#### Self-Hosted Deployment Issues
+
+**Symptoms:**
+- Server won't start
+- Process exits unexpectedly
+- Permission errors
+
+**Diagnosis:**
+```bash
+# Check server logs
+journalctl -u certus-server -f
+
+# Check process status
+systemctl status certus-server
+
+# Test manual start
+cd /opt/certus-server && node official-mcp-server.js
+```
+
+**Solutions:**
+1. **Permission issues:**
+   ```bash
+   # Fix file ownership
+   sudo chown -R node:node /opt/certus-server
+   
+   # Fix service user
+   sudo systemctl edit certus-server
+   # Add: [Service]
+   #      User=node
+   ```
+
+2. **Node.js path issues:**
+   ```bash
+   # Update service file with full path
+   ExecStart=/usr/bin/node /opt/certus-server/official-mcp-server.js
+   ```
+
+3. **Port binding issues:**
+   ```bash
+   # Allow non-root user to bind to port 443
+   sudo setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/node
+   
+   # Or use reverse proxy (recommended)
+   # See deployment guide for Nginx configuration
+   ```
+
+## Error Message Reference
+
+### Common Error Messages and Solutions
+
+#### "Connection refused"
+```
+Error: connect ECONNREFUSED 127.0.0.1:443
+```
+**Solution:** Server is not running. Check deployment status and start server.
+
+#### "Tool not found"
+```
+Tool 'search_drug_shortages' not found
+```
+**Solution:** Server may not be fully initialized. Wait 30 seconds and retry, or check server logs.
+
+#### "Rate limit exceeded"
+```
+HTTP 429: Too Many Requests
+```
+**Solution:** Add FDA API key or reduce request frequency. Wait before retrying.
+
+#### "Invalid JSON-RPC request"
+```
+Invalid request format
+```
+**Solution:** Ensure MCP client is sending proper JSON-RPC 2.0 formatted requests.
+
+#### "SSL handshake failed"
+```
+SSL routines:ssl3_get_server_certificate:certificate verify failed
+```
+**Solution:** Check SSL certificate validity or use HTTP for development testing.
+
+## Getting Help
+
+### Log Collection
+
+When reporting issues, collect these logs:
+
+1. **Server health check:**
+   ```bash
+   curl -s https://certus.opensource.mieweb.org/health | jq > health_check.json
+   ```
+
+2. **MCP inspector results:**
+   ```bash
+   npx @modelcontextprotocol/inspector https://certus.opensource.mieweb.org/mcp > mcp_inspector.txt 2>&1
+   ```
+
+3. **Tool availability:**
+   ```bash
+   curl -s https://certus.opensource.mieweb.org/tools | jq > tools_list.json
+   ```
+
+4. **Cache statistics:**
+   ```bash
+   curl -s https://certus.opensource.mieweb.org/cache-stats | jq > cache_stats.json
+   ```
+
+### Issue Reporting
+
+When reporting issues, include:
+
+1. **Environment details:**
+   - Operating system and version
+   - MCP client (Claude Desktop version, etc.)
+   - Network configuration (corporate, home, etc.)
+
+2. **Configuration:**
+   - MCP client configuration (sanitized)
+   - Any custom deployment details
+
+3. **Reproduction steps:**
+   - Exact steps to reproduce the issue
+   - Expected vs actual behavior
+   - Frequency (always, intermittent, etc.)
+
+4. **Logs and diagnostics:**
+   - Attach log files collected above
+   - Any error messages or screenshots
+
+### Contact Information
+
+- **GitHub Issues**: https://github.com/zesty-genius128/Certus_server/issues
+- **Documentation**: Check README.md and other guides in docs/ folder
+- **Server Status**: Monitor https://certus.opensource.mieweb.org/health
+
+## Preventive Maintenance
+
+### Regular Health Checks
+
+Set up monitoring for proactive issue detection:
+
+```bash
+#!/bin/bash
+# Health check script - run every 5 minutes via cron
+
+HEALTH_URL="https://certus.opensource.mieweb.org/health"
+RESPONSE=$(curl -s -w "%{http_code}" -o /dev/null "$HEALTH_URL")
+
+if [ "$RESPONSE" != "200" ]; then
+    echo "$(date): Health check failed - HTTP $RESPONSE" | tee -a /var/log/certus-monitor.log
+    # Add alerting here (email, Slack, etc.)
+fi
+```
+
+### Performance Monitoring
+
+Track key metrics over time:
+
+```bash
+#!/bin/bash
+# Performance monitoring script
+
+echo "$(date),$(curl -o /dev/null -s -w '%{time_total}' https://certus.opensource.mieweb.org/health)" >> response_times.csv
+
+CACHE_SIZE=$(curl -s https://certus.opensource.mieweb.org/cache-stats | jq '.cache.totalEntries')
+echo "$(date),cache_entries,$CACHE_SIZE" >> metrics.csv
+```
+
+### Update Procedures
+
+Keep your deployment current:
+
+1. **Monitor for updates:**
+   - Watch GitHub repository for releases
+   - Subscribe to security advisories
+
+2. **Test updates:**
+   - Deploy to staging environment first
+   - Run comprehensive test suite
+   - Verify health checks pass
+
+3. **Rollback plan:**
+   - Keep previous working version
+   - Document rollback procedures
+   - Test rollback in staging
+
+For deployment-specific update procedures, see the [Deployment Guide](deployment-guide.md).


### PR DESCRIPTION
The main README.md was refactored for brevity, with detailed deployment, configuration, testing, and troubleshooting sections moved to dedicated guides in the docs/ directory. New documentation files were added: deployment-guide.md, configuration-guide.md, testing-guide.md, and troubleshooting-guide.md, along with a docs/README.md for navigation. A backup of the previous full README was saved as backups/README-pre-wiki-backup.md. This improves maintainability and user navigation.